### PR TITLE
Fix for NNG4

### DIFF
--- a/src/lean_dojo/data_extraction/lean.py
+++ b/src/lean_dojo/data_extraction/lean.py
@@ -391,7 +391,7 @@ info_cache = RepoInfoCache()
 
 
 _GIT_REQUIREMENT_REGEX = re.compile(
-    r"require\s+(?P<name>\S+)\s+from\s+git\s+\"(?P<url>.+?)\"(\s+@\s+\"(?P<rev>\S+)\")?"
+    r"require\s+(?P<name>\S+)\s+from\s+git\s+\"(?P<url>http.+?)\"(\s+@\s+\"(?P<rev>\S+)\")?"
 )
 
 


### PR DESCRIPTION
LeanDojo gets confused by [a line](https://github.com/leanprover-community/NNG4/blob/14ee65dd9b89a8aed024d865122517f6ee494bf0/lakefile.lean#L30) in NNG4's `lakefile.lean`.

I hope it will finally work with this change. If it does, I'll upstream this change.